### PR TITLE
修复UTXO集bug

### DIFF
--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -27,8 +27,8 @@ func NewBlock(transactions []*transaction.Transaction, prevBlockHash []byte, hei
 	return block
 }
 
-// NewGenesisBlock 返回硬编码的创世区块
-func NewGenesisBlock() *Block {
+// newGenesisBlock 返回硬编码的创世区块
+func newGenesisBlock() *Block {
 	const genesisCoinbaseData = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks"
 	const genesisCoinbaseAddress = "168C3RJbprmpnxNry49ftjWGfFGQTNeDsU"
 

--- a/cli/cli_listaddress.go
+++ b/cli/cli_listaddress.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"blockchain_go/utils"
 	"blockchain_go/wallet"
 	"fmt"
 	"log"
@@ -14,6 +15,8 @@ func (cli *CLI) listAddresses(nodeID string) {
 	addresses := wallets.GetAddresses()
 
 	for _, address := range addresses {
-		fmt.Println(address)
+		pubKeyHash := utils.Base58Decode([]byte(address))
+		pubKeyHash = pubKeyHash[1 : len(pubKeyHash)-4]
+		fmt.Printf("address: %s, pubHash: %x \n", address, pubKeyHash)
 	}
 }

--- a/transaction/transaction_output.go
+++ b/transaction/transaction_output.go
@@ -3,8 +3,6 @@ package transaction
 import (
 	"blockchain_go/utils"
 	"bytes"
-	"encoding/gob"
-	"log"
 )
 
 // TXOutput represents a transaction output
@@ -31,35 +29,4 @@ func NewTXOutput(value int, address string) *TXOutput {
 	txo.Lock([]byte(address))
 
 	return txo
-}
-
-// TXOutputs collects TXOutput
-type TXOutputs struct {
-	Outputs []TXOutput
-}
-
-// Serialize serializes TXOutputs
-func (outs TXOutputs) Serialize() []byte {
-	var buff bytes.Buffer
-
-	enc := gob.NewEncoder(&buff)
-	err := enc.Encode(outs)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	return buff.Bytes()
-}
-
-// DeserializeOutputs deserializes TXOutputs
-func DeserializeOutputs(data []byte) TXOutputs {
-	var outputs TXOutputs
-
-	dec := gob.NewDecoder(bytes.NewReader(data))
-	err := dec.Decode(&outputs)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	return outputs
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,10 +2,13 @@ package utils
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/sha256"
 	"encoding/binary"
 	"golang.org/x/crypto/ripemd160"
 	"log"
+	"math/big"
 )
 
 // IntToHex converts an int64 to a byte array
@@ -38,4 +41,25 @@ func HashPubKey(pubKey []byte) []byte {
 	publicRIPEMD160 := RIPEMD160Hasher.Sum(nil)
 
 	return publicRIPEMD160
+}
+
+// SignatureCheck 通过签名和公钥校验数据合法性
+func SignatureCheck(signature, pubey, dataToVerify []byte) bool {
+	r := big.Int{}
+	s := big.Int{}
+	sigLen := len(signature)
+	r.SetBytes(signature[:(sigLen / 2)])
+	s.SetBytes(signature[(sigLen / 2):])
+
+	x := big.Int{}
+	y := big.Int{}
+	keyLen := len(pubey)
+	x.SetBytes(pubey[:(keyLen / 2)])
+	y.SetBytes(pubey[(keyLen / 2):])
+
+	rawPubKey := ecdsa.PublicKey{Curve: elliptic.P256(), X: &x, Y: &y}
+	if ecdsa.Verify(&rawPubKey, dataToVerify, &r, &s) == false {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
1. 之前的UTXO集没有保存输出在交易中的索引，导致创建交易时可能不能正确构造输入。
2. Transaction.Verify 交易校验函数没有校验当前输入和所引用的输出地址相同，导致可以花费别人的UTXO

